### PR TITLE
Change DoRender method to avoid possible exceptions

### DIFF
--- a/Source/Blade/Views/WebControlView.cs
+++ b/Source/Blade/Views/WebControlView.cs
@@ -46,7 +46,13 @@ namespace Blade.Views
 		/// <param name="output">The HtmlTextWriter for the Page/Response</param>
 		protected override void DoRender(HtmlTextWriter output)
 		{
-			using (new RenderingDiagnostics(output, GetType().FullName, Cacheable, VaryByData, VaryByDevice, VaryByLogin, VaryByParm, VaryByQueryString, VaryByUser, ClearOnIndexUpdate, GetCachingID()))
+            string CachingID = null;
+            try
+            {
+                CachingID = GetCachingID();
+            }
+            catch { }
+			using (new RenderingDiagnostics(output, GetType().FullName, Cacheable, VaryByData, VaryByDevice, VaryByLogin, VaryByParm, VaryByQueryString, VaryByUser, ClearOnIndexUpdate, CachingID))
 			{
 				if (Model != null)
 					RenderModel(output);


### PR DESCRIPTION
It's common for the GetCachingID() method to try to access properties on the Model, which will throw an exception if the Model is null. This change allows GetCachingID methods to assume that their Model is not null.
