### PR TITLE
Sitecore 8 Update

### DIFF
--- a/Source/Blade/Blade.csproj
+++ b/Source/Blade/Blade.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Blade</RootNamespace>
     <AssemblyName>Blade</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>

--- a/Source/Blade/Blade.csproj
+++ b/Source/Blade/Blade.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Blade</RootNamespace>
     <AssemblyName>Blade</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>

--- a/Source/Blade/Blade.csproj
+++ b/Source/Blade/Blade.csproj
@@ -36,9 +36,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Sitecore.Buckets">
-      <HintPath>..\..\Dependencies\Libraries\Sitecore\Sitecore.Buckets.dll</HintPath>
-    </Reference>
     <Reference Include="Sitecore.ContentSearch">
       <HintPath>..\..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.dll</HintPath>
     </Reference>

--- a/Source/Blade/Pipelines/ResolveRenderingDataSource/HandleSearch.cs
+++ b/Source/Blade/Pipelines/ResolveRenderingDataSource/HandleSearch.cs
@@ -1,59 +1,58 @@
-﻿using System.Linq;
-using Sitecore.Buckets.Util;
-using Sitecore.ContentSearch;
+﻿using Sitecore.ContentSearch;
 using Sitecore.ContentSearch.SearchTypes;
 using Sitecore.ContentSearch.Utilities;
 using Sitecore.Data.Items;
+using System.Linq;
 
 namespace Blade.Pipelines.ResolveRenderingDataSource
 {
-	/// <summary>
-	/// Handles data sources that are defined using index search syntax
-	/// TODO: when Update-2 comes out, supposedly the UIFilterHelpers.ParseDatasourceString will become generic.
-	/// If that happens, this pipeline should be refactored to allow returning a strongly typed data source item in addition to
-	/// the Item result so as to avoid having to pre-convert search results to Items.
-	/// </summary>
-	public class HandleSearch : ResolveRenderingDataSourcePipelineProcessor
-	{
-		public override void DoProcess(ResolveRenderingDataSourceArgs args)
-		{
-			// if a search context came in, we don't dispose it when done - otherwise we dispose our temp context
-			bool disposeSearchContext = args.SearchContext == null;
+    /// <summary>
+    /// Handles data sources that are defined using index search syntax
+    /// TODO: when Update-2 comes out, supposedly the UIFilterHelpers.ParseDatasourceString will become generic.
+    /// If that happens, this pipeline should be refactored to allow returning a strongly typed data source item in addition to
+    /// the Item result so as to avoid having to pre-convert search results to Items.
+    /// </summary>
+    public class HandleSearch : ResolveRenderingDataSourcePipelineProcessor
+    {
+        public override void DoProcess(ResolveRenderingDataSourceArgs args)
+        {
+            // if a search context came in, we don't dispose it when done - otherwise we dispose our temp context
+            bool disposeSearchContext = args.SearchContext == null;
 
-			IProviderSearchContext searchContext = null;
-			try
-			{
-				searchContext = args.SearchContext ?? ContentSearchManager.CreateSearchContext(new SitecoreIndexableItem(args.ContextItem));
+            IProviderSearchContext searchContext = null;
+            try
+            {
+                searchContext = args.SearchContext ?? ContentSearchManager.CreateSearchContext(new SitecoreIndexableItem(args.ContextItem));
 
-				var query = CreateQuery(searchContext, args.DataSource);
+                var query = CreateQuery(searchContext, args.DataSource);
 
-				args.DataSourceItems.AddRange(ProcessQueryResults(query));
-			}
-			finally
-			{
-				if(disposeSearchContext && searchContext != null) searchContext.Dispose();
-			}
-		}
+                args.DataSourceItems.AddRange(ProcessQueryResults(query));
+            }
+            finally
+            {
+                if (disposeSearchContext && searchContext != null) searchContext.Dispose();
+            }
+        }
 
-		protected virtual IQueryable<SitecoreUISearchResultItem> CreateQuery(IProviderSearchContext context, string query)
-		{
-			var parsedQuery = UIFilterHelpers.ParseDatasourceString(query);
-			var linqQuery = LinqHelper.CreateQuery(context, parsedQuery);
+        protected virtual IQueryable<SitecoreUISearchResultItem> CreateQuery(IProviderSearchContext context, string query)
+        {
+            var parsedQuery = SearchStringModel.ParseDatasourceString(query);
+            var linqQuery = LinqHelper.CreateQuery(context, parsedQuery);
 
-			return FilterQuery(linqQuery);
-		}
+            return FilterQuery(linqQuery);
+        }
 
-		protected virtual IQueryable<SitecoreUISearchResultItem> FilterQuery(IQueryable<SitecoreUISearchResultItem> query)
-		{
-			string language = Sitecore.Context.Language.CultureInfo.TwoLetterISOLanguageName;
+        protected virtual IQueryable<SitecoreUISearchResultItem> FilterQuery(IQueryable<SitecoreUISearchResultItem> query)
+        {
+            string language = Sitecore.Context.Language.CultureInfo.TwoLetterISOLanguageName;
 
-			// this makes us get "normal" query behavior of returning context language and latest version only
-			return query.Where(x => x.Language == language && x["_latestversion"] == "1");
-		}
+            // this makes us get "normal" query behavior of returning context language and latest version only
+            return query.Where(x => x.Language == language && x["_latestversion"] == "1");
+        }
 
-		protected virtual Item[] ProcessQueryResults(IQueryable<SitecoreUISearchResultItem> query)
-		{
-			return query.Select(x => x.GetItem()).ToArray();
-		}
-	}
+        protected virtual Item[] ProcessQueryResults(IQueryable<SitecoreUISearchResultItem> query)
+        {
+            return query.Select(x => x.GetItem()).ToArray();
+        }
+    }
 }

--- a/Source/Blade/Razor/RazorRendering.cs
+++ b/Source/Blade/Razor/RazorRendering.cs
@@ -17,7 +17,7 @@ namespace Blade.Razor
 		/// <summary>
 		/// Checks if the page is in inline edit mode (by an author)
 		/// </summary>
-		public bool IsEditing { get { return Sitecore.Context.PageMode.IsPageEditor; } }
+		public bool IsEditing { get { return Sitecore.Context.PageMode.IsExperienceEditor; } }
 
 		/// <summary>
 		/// Checks if the page is being viewed in preview mode

--- a/Source/Blade/Views/UserControlView.cs
+++ b/Source/Blade/Views/UserControlView.cs
@@ -100,7 +100,7 @@ namespace Blade.Views
 		/// <summary>
 		/// Checks if the page is in inline edit mode (by an author)
 		/// </summary>
-		protected bool IsEditing { get { return Sitecore.Context.PageMode.IsPageEditor; } }
+		protected bool IsEditing { get { return Sitecore.Context.PageMode.IsExperienceEditor; } }
 
 		/// <summary>
 		/// Checks if the page is being viewed in preview mode

--- a/Source/Blade/Views/WebControlView.cs
+++ b/Source/Blade/Views/WebControlView.cs
@@ -32,7 +32,7 @@ namespace Blade.Views
 		/// <summary>
 		/// Checks if the page is in inline edit mode (by an author)
 		/// </summary>
-		protected bool IsEditing { get { return Sitecore.Context.PageMode.IsPageEditor; } }
+		protected bool IsEditing { get { return Sitecore.Context.PageMode.IsExperienceEditor; } }
 
 		/// <summary>
 		/// Checks if the page is being viewed in preview mode


### PR DESCRIPTION
This is an update for anyone using this in some capacity in Sitecore 8 and over. For example a project I'm on is using `DataSourceHelper.ResolveDataSource`. I believe the change for `HandleSearch.cs` is necessary from 7.5 and beyond. Other updates were just changing things referencing `IsPageEditor` to `IsExperienceEditor` and bumping the .net framework version to work with newer Sitecore dlls.